### PR TITLE
chore: remove team page from site navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { HashRouter as Router, Switch } from 'react-router-dom';
 import { Route } from 'react-router-dom';
-import { Home, Team, Podcast, Covidsations, Blog, BlogPage } from './pages/index';
+import { Home, Podcast, Covidsations, Blog, BlogPage } from './pages/index';
 
 function App() {
-  return (
+    return (
     <Router basename='/'>
       <Switch>
-        <Route exact path ="/team">
-          < Team />
-        </Route>
         <Route exact path ="/podcast">
           < Podcast />
         </Route>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,32 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+describe('App routing', () => {
+  afterEach(() => {
+    window.location.hash = '#/';
+  });
+
+  test('does not show a Team navigation link on the home page', () => {
+    // Arrange
+    window.location.hash = '#/';
+
+    // Act
+    render(<App />);
+
+    // Assert
+    expect(screen.getByText('Archive')).toBeInTheDocument();
+    expect(screen.getByText('Podcast')).toBeInTheDocument();
+    expect(screen.queryByText('Team')).not.toBeInTheDocument();
+  });
+
+  test('does not render the team page at the previous team route', () => {
+    // Arrange
+    window.location.hash = '#/team';
+
+    // Act
+    render(<App />);
+
+    // Assert
+    expect(screen.queryByText('About the Founder')).not.toBeInTheDocument();
+  });
 });

--- a/src/containers/header.js
+++ b/src/containers/header.js
@@ -15,7 +15,6 @@ export function HeaderContainer() {
                 <Header.LinkContainer>
                     <Header.StyledLink to="/blog">Archive</Header.StyledLink>
                     <Header.StyledLink to="/podcast">Podcast</Header.StyledLink>
-                    <Header.StyledLink to="/team">Team</Header.StyledLink>
                 </Header.LinkContainer>
                 <Header.StyledBurgerContainer onClick={() => setOpen(!open)}>
                     <Header.StyledBurger open={open}>
@@ -33,11 +32,7 @@ export function HeaderContainer() {
                 <Header.DropdownMenuText open={open}>
                     <Header.DropdownLink to="/podcast">Podcast</Header.DropdownLink>
                 </Header.DropdownMenuText>
-                <Header.DropdownMenuText open={open}>
-                    <Header.DropdownLink to="/team">Team</Header.DropdownLink>
-                </Header.DropdownMenuText>
             </Header.DropdownMenuContainer>
         </Header>
     )
 }
-

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,8 +1,7 @@
 import Home from './home';
-import Team from './team'
 import Podcast from './podcast'
 import Covidsations from './covidsations'
 import Blog from './blog'
 import BlogPage from './blogpage'
 
-export {Home, Team, Podcast, Covidsations, Blog, BlogPage}
+export {Home, Podcast, Covidsations, Blog, BlogPage}


### PR DESCRIPTION
## Summary
- Remove the `Team` link from the desktop header navigation
- Remove the `Team` link from the mobile dropdown navigation
- Remove the `/team` route from the app router
- Replace the default CRA test with coverage for the removed nav item and route

## Problem
The site still exposes a `Team` page in navigation and routing, but the requested site structure no longer includes that page.

## Solution
Remove the `Team` entry from the header component and stop exporting and routing the page in the app shell. Add a focused app-level test that asserts the navigation no longer shows `Team` and that `#/team` no longer renders the previous team page content.

## Related
None

## Scope
Feature: site navigation and routing

## Test Plan
- [ ] Unit tests pass
- [ ] Build succeeds

Test status in this environment:
- `CI=true npm test -- --watch=false --runInBand src/App.test.js` is currently blocked because `react-scripts` is not installed before dependency install
- `npm ci` is currently blocked by a registry 404 for `social-media-icons-react@1.1.7` from the existing lockfile